### PR TITLE
evaluate pacman line count directly

### DIFF
--- a/blocks/packages
+++ b/blocks/packages
@@ -1,14 +1,12 @@
 #!/usr/bin/bash
 
-PACKAGES=$(pacman -Qu)
-
 URGENT_VALUE=25
 
 if [[ $? -gt 0 ]]; then
   return
 fi
 
-PACKAGE_COUNT=$(echo "${PACKAGES}" | wc -l)
+PACKAGE_COUNT=$(pacman -Qu | wc -l)
 
 if [[ "${PACKAGE_COUNT}" -gt 0 ]]; then
   echo "${PACKAGE_COUNT}" # full-text

--- a/blocks/packages
+++ b/blocks/packages
@@ -1,11 +1,6 @@
 #!/usr/bin/bash
 
 URGENT_VALUE=25
-
-if [[ $? -gt 0 ]]; then
-  return
-fi
-
 PACKAGE_COUNT=$(pacman -Qu | wc -l)
 
 if [[ "${PACKAGE_COUNT}" -gt 0 ]]; then


### PR DESCRIPTION
I noticed the blocklet reporting 1 update even when `pacman -Qu` returned no names -- turned out that even though `$PACKAGES` was properly empty, echoing it appended a newline which got picked up by `wc`.
