### PR TITLE
just interpolate artist/title into OUT_TEXT for cmus

### DIFF
--- a/blocks/cmus
+++ b/blocks/cmus
@@ -10,9 +10,9 @@ else
 fi
 
 if [[ "${INFO_ARTIST}" ]] && [[ "${INFO_TITLE}" ]]; then
-  OUT_TEXT=$(echo "${INFO_ARTIST} - ${INFO_TITLE}" | xargs)
+  OUT_TEXT="${INFO_ARTIST} - ${INFO_TITLE}"
 elif [[ "${INFO_TITLE}" ]]; then
-  OUT_TEXT=$(echo "${INFO_TITLE}" | xargs)
+  OUT_TEXT="${INFO_TITLE}"
 fi
 
 echo "${OUT_TEXT}"


### PR DESCRIPTION
Songs where the title contains an apostrophe do not display completely ("The Devil & The Universe - Parvati's Lament" displays as "The Devil & The Universe -", while "Fear - New York's Alright If You Like Saxophones" becomes "Fear - New"). I don't think it needs to be passed to xargs.