### PR TITLE
Auto check for interface

### DIFF
--- a/blocks/bandwidth
+++ b/blocks/bandwidth
@@ -2,9 +2,11 @@
 # Source: http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html
 
 INSTANCE="${BLOCK_INSTANCE}"
+# If you don't like you can use any other IP
+INTERFACE="$(ip route get 8.8.8.8 | grep -Po '(?<=(dev )).*(?= src)')"
 
 if [[ "${INSTANCE}" = "" ]]; then
-  INSTANCE="wlp3s0;both"
+  INSTANCE="${INTERFACE};both"
 fi
 
 DISPLAY=$(echo "${INSTANCE}" | awk -F ';' '{print $2}')


### PR DESCRIPTION
Now the default interface is auto discovered with ip route and a simple ip address.
Now you can use 1 block for you networks in your .i3blocks.conf and automatically switches from enp0s25 to wlan0 or something else.