### PR TITLE
Minor fixes in brightness and weather scripts

### DIFF
--- a/blocks/brightness
+++ b/blocks/brightness
@@ -37,7 +37,7 @@ fi
 if [[ "${METHOD}" = "xrandr" ]]; then
   percent=$(echo "scale=0;${curBrightness} * 100" | bc -l)
 elif [[ "${METHOD}" = "kernel" ]]; then
-  percent=$(echo "scale=0;${curBrightness} / ${maxBrightness} * 100" | bc -l)
+  percent=$(echo "scale=0;100 * ${curBrightness} / ${maxBrightness}" | bc -l)
 elif [[ "${METHOD}" = "xbacklight" ]]; then
   percent=$(echo "scale=0;${curBrightness}" | bc -l)
 fi

--- a/blocks/weather
+++ b/blocks/weather
@@ -6,9 +6,6 @@ API_KEY="44db6a862fba0b067b1930da0d769e98"
 # Check on http://openweathermap.org/find
 CITY_ID="${BLOCK_INSTANCE}"
 
-URGENT_LOWER=0
-URGENT_HIGHER=30
-
 ICON_SUNNY=""
 ICON_CLOUDY=""
 ICON_RAINY=""
@@ -21,35 +18,40 @@ SYMBOL_CELSIUS="℃"
 WEATHER_URL="http://api.openweathermap.org/data/2.5/weather?id=${CITY_ID}&appid=${API_KEY}&units=metric"
 
 WEATHER_INFO=$(wget -qO- "${WEATHER_URL}")
+
+if [[ -z "${WEATHER_INFO}" ]]; then
+  exit 1
+fi
+
 WEATHER_MAIN=$(echo "${WEATHER_INFO}" | grep -o -e '\"main\":\"[a-Z]*\"' | awk -F ':' '{print $2}' | tr -d '"')
 WEATHER_TEMP=$(echo "${WEATHER_INFO}" | grep -o -e '\"temp\":\-\?[0-9]*' | awk -F ':' '{print $2}' | tr -d '"')
 
 if [[ "${WEATHER_MAIN}" = *Snow* ]]; then
   echo "${ICON_SNOW} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
   echo "${ICON_SNOW} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
-  echo ""
 elif [[ "${WEATHER_MAIN}" = *Rain* ]] || [[ "${WEATHER_MAIN}" = *Drizzle* ]]; then
   echo "${ICON_RAINY} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
   echo "${ICON_RAINY} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
-  echo ""
 elif [[ "${WEATHER_MAIN}" = *Cloud* ]]; then
   echo "${ICON_CLOUDY} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
   echo "${ICON_CLOUDY} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
-  echo ""
 elif [[ "${WEATHER_MAIN}" = *Clear* ]]; then
   echo "${ICON_SUNNY} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
   echo "${ICON_SUNNY} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
-  echo ""
 elif [[ "${WEATHER_MAIN}" = *Fog* ]] || [[ "${WEATHER_MAIN}" = *Mist* ]]; then
   echo "${ICON_FOG} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
   echo "${ICON_FOG} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
-  echo ""
 else
   echo "${WEATHER_MAIN} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
   echo "${WEATHER_MAIN} ${WEATHER_TEMP}${SYMBOL_CELSIUS}"
-  echo ""
 fi
 
-if [[ "${WEATHER_TEMP}" -lt "${URGENT_LOWER}" ]] || [[ "${WEATHER_TEMP}" -gt "${URGENT_HIGHER}" ]]; then
-  exit 33
+if [[ "${WEATHER_TEMP}" -ge 30 ]]; then
+  echo "#FF0000"
+elif [[ "${WEATHER_TEMP}" -ge 15 ]]; then
+  echo "#FF8800"
+elif [[ "${WEATHER_TEMP}" -gt 0 ]]; then
+  echo "#FFFF00"
+elif [[ "${WEATHER_TEMP}" -le 0 ]]; then
+  echo "#0088FF"
 fi


### PR DESCRIPTION
**Brightness**

There is a bug in brightness calculation in kernel mode. 
```
echo "scale=0;${curBrightness} / ${maxBrightness} * 100" | bc -l
```
Above line will output just 0. Try:
```
echo "scale=0;150 / 255 * 100" | bc -l
```
"100" multiplier should be placed in the beginning as in the fixed code.

**Weather**
When offline, script outputs plain "℃" without any temperature. I suggest checking if `${WEATHER_INFO}` var is empty and exiting with 1 if it is (see code).
Also, I added some colors. Check out yourself if you like it.