### PR TITLE
use `checkupdates` rather than `pacman -Qu`

### DIFF
--- a/blocks/packages
+++ b/blocks/packages
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 URGENT_VALUE=25
-PACKAGE_COUNT=$(pacman -Qu | wc -l)
+PACKAGE_COUNT=$(checkupdates | wc -l)
 
 if [[ "${PACKAGE_COUNT}" -gt 0 ]]; then
   echo "${PACKAGE_COUNT}" # full-text


### PR DESCRIPTION
* `checkupdates` is a helper script provided by pacman that will safely
  check for packages to update

https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported