### PR TITLE
Fixed issue with brightness script, METHOD="kernel"

### DIFF
--- a/blocks/brightness
+++ b/blocks/brightness
@@ -37,7 +37,7 @@ fi
 if [[ "${METHOD}" = "xrandr" ]]; then
   percent=$(echo "scale=0;${curBrightness} * 100" | bc -l)
 elif [[ "${METHOD}" = "kernel" ]]; then
-  percent=$(echo "scale=0;${curBrightness} / ${maxBrightness} * 100" | bc -l)
+  percent=$(echo "scale=0;${curBrightness} * 100 / ${maxBrightness}" | bc -l)
 elif [[ "${METHOD}" = "xbacklight" ]]; then
   percent=$(echo "scale=0;${curBrightness}" | bc -l)
 fi


### PR DESCRIPTION
The percentage calculation for brightness in kernel mode would always be 0 (probably because bc -l converts to integer before executing division). Moving * 100 to before the division fixes the issue and returns the correct percentage.

PS: I realise the project is no longer maintained, it's a tiny bug that I just noticed when I used your script.